### PR TITLE
feat(client): add Watch for streaming daemon state events

### DIFF
--- a/contrib/keylightd-tray/frontend/package-lock.json
+++ b/contrib/keylightd-tray/frontend/package-lock.json
@@ -12,21 +12,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -46,14 +46,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -65,9 +65,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
       "cpu": [
         "arm64"
       ],
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
       "cpu": [
         "arm64"
       ],
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
       "cpu": [
         "x64"
       ],
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
       "cpu": [
         "x64"
       ],
@@ -143,9 +143,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
       "cpu": [
         "arm"
       ],
@@ -160,9 +160,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
       "cpu": [
         "arm64"
       ],
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
       "cpu": [
         "arm64"
       ],
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
       "cpu": [
         "ppc64"
       ],
@@ -220,9 +220,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
       "cpu": [
         "s390x"
       ],
@@ -240,9 +240,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
       "cpu": [
         "x64"
       ],
@@ -260,9 +260,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
       "cpu": [
         "x64"
       ],
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
       "cpu": [
         "arm64"
       ],
@@ -297,9 +297,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
       "cpu": [
         "wasm32"
       ],
@@ -307,18 +307,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
       "cpu": [
         "arm64"
       ],
@@ -333,9 +333,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
       "cpu": [
         "x64"
       ],
@@ -357,9 +357,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -684,9 +684,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.14",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.14.tgz",
-      "integrity": "sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -752,13 +752,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.133.0",
+        "@oxc-project/types": "=0.138.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -768,21 +768,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
       }
     },
     "node_modules/source-map-js": {
@@ -821,16 +821,16 @@
       "optional": true
     },
     "node_modules/vite": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -847,7 +847,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/internal/server/socket_actions_test.go
+++ b/internal/server/socket_actions_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jmylchreest/keylightd/internal/config"
 	"github.com/jmylchreest/keylightd/internal/events"
+	"github.com/jmylchreest/keylightd/pkg/client"
 	"github.com/jmylchreest/keylightd/pkg/keylight"
 
 	"log/slog"
@@ -463,4 +464,34 @@ func TestSocketAction_SubscribeEvents(t *testing.T) {
 	err = json.NewDecoder(conn).Decode(&evt)
 	require.NoError(t, err)
 	assert.Equal(t, "light.state_changed", evt["type"])
+}
+
+// --- Client Watch end-to-end ---
+
+func TestSocketAction_ClientWatch(t *testing.T) {
+	server, socketPath := setupSocketTest(t)
+
+	c := client.New(slog.New(slog.DiscardHandler), socketPath)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := c.Watch(ctx)
+	require.NoError(t, err)
+
+	server.eventBus.Publish(events.NewEvent(events.LightStateChanged, map[string]string{"id": "light-1"}))
+
+	select {
+	case e := <-ch:
+		assert.Equal(t, string(events.LightStateChanged), e.Type)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+
+	cancel()
+	select {
+	case _, ok := <-ch:
+		assert.False(t, ok, "channel should close after cancel")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for channel close")
+	}
 }

--- a/pkg/client/watch.go
+++ b/pkg/client/watch.go
@@ -5,11 +5,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
+)
+
+const (
+	watchHandshakeTimeout = 10 * time.Second
+	// The daemon pings every ~54s; a stale read deadline detects dead peers.
+	wsReadTimeout  = 90 * time.Second
+	wsWriteTimeout = 10 * time.Second
 )
 
 // Event is a state-change event streamed from the daemon. It mirrors the
@@ -33,56 +42,17 @@ var (
 	_ Watcher = (*HTTPClient)(nil)
 )
 
-// Watch subscribes to daemon events over the unix socket.
-func (c *Client) Watch(ctx context.Context) (<-chan Event, error) {
-	conn, err := dial("unix", c.socket)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to socket: %w", err)
-	}
-
-	// Deadline covers the handshake only; streaming reads must not time out.
-	if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
-		_ = conn.Close()
-		return nil, fmt.Errorf("failed to set connection deadline: %w", err)
-	}
-
-	if err := json.NewEncoder(conn).Encode(map[string]string{"action": "subscribe_events"}); err != nil {
-		_ = conn.Close()
-		return nil, fmt.Errorf("failed to send subscribe request: %w", err)
-	}
-
-	reader := bufio.NewReader(conn)
-	line, err := reader.ReadBytes('\n')
-	if err != nil {
-		_ = conn.Close()
-		return nil, fmt.Errorf("failed to read subscribe response: %w", err)
-	}
-	if err := conn.SetDeadline(time.Time{}); err != nil {
-		_ = conn.Close()
-		return nil, fmt.Errorf("failed to clear connection deadline: %w", err)
-	}
-
-	var ack map[string]any
-	if err := json.Unmarshal(line, &ack); err != nil {
-		_ = conn.Close()
-		return nil, fmt.Errorf("invalid subscribe response: %w", err)
-	}
-	if errMsg, ok := ack["error"].(string); ok {
-		_ = conn.Close()
-		return nil, fmt.Errorf("server error: %s", errMsg)
-	}
-	if subscribed, _ := ack["subscribed"].(bool); !subscribed {
-		_ = conn.Close()
-		return nil, fmt.Errorf("unexpected subscribe response: %s", strings.TrimSpace(string(line)))
-	}
-
+// streamEvents decodes raw messages from next into a channel of events.
+// closeConn unblocks next on ctx cancellation and runs again when the read
+// loop exits; it must be safe to call concurrently and repeatedly.
+func streamEvents(ctx context.Context, logger *slog.Logger, next func() ([]byte, error), closeConn func()) <-chan Event {
 	events := make(chan Event, 64)
 	done := make(chan struct{})
 
 	go func() {
 		select {
 		case <-ctx.Done():
-			_ = conn.Close()
+			closeConn()
 		case <-done:
 		}
 	}()
@@ -90,15 +60,15 @@ func (c *Client) Watch(ctx context.Context) (<-chan Event, error) {
 	go func() {
 		defer close(events)
 		defer close(done)
-		defer conn.Close()
+		defer closeConn()
 		for {
-			line, err := reader.ReadBytes('\n')
+			msg, err := next()
 			if err != nil {
 				return
 			}
 			var e Event
-			if err := json.Unmarshal(line, &e); err != nil {
-				c.logger.Warn("watch: skipping malformed event", "error", err)
+			if err := json.Unmarshal(msg, &e); err != nil {
+				logger.Warn("watch: skipping malformed event", "error", err)
 				continue
 			}
 			select {
@@ -109,7 +79,64 @@ func (c *Client) Watch(ctx context.Context) (<-chan Event, error) {
 		}
 	}()
 
-	return events, nil
+	return events
+}
+
+// Watch subscribes to daemon events over the unix socket.
+func (c *Client) Watch(ctx context.Context) (<-chan Event, error) {
+	conn, err := dial("unix", c.socket)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to socket: %w", err)
+	}
+
+	reader := bufio.NewReader(conn)
+	if err := subscribeEvents(ctx, conn, reader); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+
+	next := func() ([]byte, error) { return reader.ReadBytes('\n') }
+	return streamEvents(ctx, c.logger, next, func() { _ = conn.Close() }), nil
+}
+
+// subscribeEvents performs the subscribe_events handshake. The deadline
+// bounds a hung daemon; the goroutine unblocks reads on ctx cancellation.
+func subscribeEvents(ctx context.Context, conn net.Conn, reader *bufio.Reader) error {
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-stop:
+		}
+	}()
+
+	if err := conn.SetDeadline(time.Now().Add(watchHandshakeTimeout)); err != nil {
+		return fmt.Errorf("failed to set connection deadline: %w", err)
+	}
+	if err := json.NewEncoder(conn).Encode(map[string]string{"action": "subscribe_events"}); err != nil {
+		return fmt.Errorf("failed to send subscribe request: %w", err)
+	}
+	line, err := reader.ReadBytes('\n')
+	if err != nil {
+		return fmt.Errorf("failed to read subscribe response: %w", err)
+	}
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		return fmt.Errorf("failed to clear connection deadline: %w", err)
+	}
+
+	var ack map[string]any
+	if err := json.Unmarshal(line, &ack); err != nil {
+		return fmt.Errorf("invalid subscribe response: %w", err)
+	}
+	if errMsg, ok := ack["error"].(string); ok {
+		return fmt.Errorf("server error: %s", errMsg)
+	}
+	if subscribed, _ := ack["subscribed"].(bool); !subscribed {
+		return fmt.Errorf("unexpected subscribe response: %s", strings.TrimSpace(string(line)))
+	}
+	return nil
 }
 
 // Watch subscribes to daemon events over the WebSocket endpoint.
@@ -127,53 +154,35 @@ func (c *HTTPClient) Watch(ctx context.Context) (<-chan Event, error) {
 		header.Set("X-API-Key", c.apiKey)
 	}
 
-	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, wsURL, header) //nolint:bodyclose // body closed below
+	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, wsURL, header) //nolint:bodyclose // closed below
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
 	if err != nil {
 		if resp != nil {
-			_ = resp.Body.Close()
 			return nil, fmt.Errorf("failed to connect to %s (status %d): %w", wsURL, resp.StatusCode, err)
 		}
 		return nil, fmt.Errorf("failed to connect to %s: %w", wsURL, err)
 	}
-	if resp != nil {
-		_ = resp.Body.Close()
+
+	_ = conn.SetReadDeadline(time.Now().Add(wsReadTimeout))
+	conn.SetPingHandler(func(msg string) error {
+		_ = conn.SetReadDeadline(time.Now().Add(wsReadTimeout))
+		return conn.WriteControl(websocket.PongMessage, []byte(msg), time.Now().Add(wsWriteTimeout))
+	})
+
+	next := func() ([]byte, error) {
+		_, msg, err := conn.ReadMessage()
+		if err == nil {
+			_ = conn.SetReadDeadline(time.Now().Add(wsReadTimeout))
+		}
+		return msg, err
 	}
-
-	events := make(chan Event, 64)
-	done := make(chan struct{})
-
-	go func() {
-		select {
-		case <-ctx.Done():
-			_ = conn.WriteControl(websocket.CloseMessage,
-				websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
-				time.Now().Add(time.Second))
-			_ = conn.Close()
-		case <-done:
-		}
-	}()
-
-	go func() {
-		defer close(events)
-		defer close(done)
-		defer conn.Close()
-		for {
-			_, msg, err := conn.ReadMessage()
-			if err != nil {
-				return
-			}
-			var e Event
-			if err := json.Unmarshal(msg, &e); err != nil {
-				c.logger.Warn("watch: skipping malformed event", "error", err)
-				continue
-			}
-			select {
-			case events <- e:
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	return events, nil
+	closeConn := func() {
+		_ = conn.WriteControl(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+			time.Now().Add(time.Second))
+		_ = conn.Close()
+	}
+	return streamEvents(ctx, c.logger, next, closeConn), nil
 }

--- a/pkg/client/watch.go
+++ b/pkg/client/watch.go
@@ -122,9 +122,9 @@ func subscribeEvents(ctx context.Context, conn net.Conn, reader *bufio.Reader) e
 	if err != nil {
 		return fmt.Errorf("failed to read subscribe response: %w", err)
 	}
-	if err := conn.SetDeadline(time.Time{}); err != nil {
-		return fmt.Errorf("failed to clear connection deadline: %w", err)
-	}
+	// Best-effort: if this fails the conn is already dead and the stream
+	// loop will surface it as a closed channel.
+	_ = conn.SetDeadline(time.Time{})
 
 	var ack map[string]any
 	if err := json.Unmarshal(line, &ack); err != nil {

--- a/pkg/client/watch.go
+++ b/pkg/client/watch.go
@@ -1,0 +1,179 @@
+package client
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// Event is a state-change event streamed from the daemon. It mirrors the
+// daemon's internal event format used by both the unix socket and WebSocket
+// transports.
+type Event struct {
+	Type      string          `json:"type"`
+	Timestamp time.Time       `json:"timestamp"`
+	Data      json.RawMessage `json:"data"`
+}
+
+// Watcher is implemented by clients that support streaming state-change
+// events. The returned channel is closed when ctx is done or the
+// connection drops; callers are responsible for re-subscribing.
+type Watcher interface {
+	Watch(ctx context.Context) (<-chan Event, error)
+}
+
+var (
+	_ Watcher = (*Client)(nil)
+	_ Watcher = (*HTTPClient)(nil)
+)
+
+// Watch subscribes to daemon events over the unix socket.
+func (c *Client) Watch(ctx context.Context) (<-chan Event, error) {
+	conn, err := dial("unix", c.socket)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to socket: %w", err)
+	}
+
+	// Deadline covers the handshake only; streaming reads must not time out.
+	if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("failed to set connection deadline: %w", err)
+	}
+
+	if err := json.NewEncoder(conn).Encode(map[string]string{"action": "subscribe_events"}); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("failed to send subscribe request: %w", err)
+	}
+
+	reader := bufio.NewReader(conn)
+	line, err := reader.ReadBytes('\n')
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("failed to read subscribe response: %w", err)
+	}
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("failed to clear connection deadline: %w", err)
+	}
+
+	var ack map[string]any
+	if err := json.Unmarshal(line, &ack); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("invalid subscribe response: %w", err)
+	}
+	if errMsg, ok := ack["error"].(string); ok {
+		_ = conn.Close()
+		return nil, fmt.Errorf("server error: %s", errMsg)
+	}
+	if subscribed, _ := ack["subscribed"].(bool); !subscribed {
+		_ = conn.Close()
+		return nil, fmt.Errorf("unexpected subscribe response: %s", strings.TrimSpace(string(line)))
+	}
+
+	events := make(chan Event, 64)
+	done := make(chan struct{})
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.Close()
+		case <-done:
+		}
+	}()
+
+	go func() {
+		defer close(events)
+		defer close(done)
+		defer conn.Close()
+		for {
+			line, err := reader.ReadBytes('\n')
+			if err != nil {
+				return
+			}
+			var e Event
+			if err := json.Unmarshal(line, &e); err != nil {
+				c.logger.Warn("watch: skipping malformed event", "error", err)
+				continue
+			}
+			select {
+			case events <- e:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return events, nil
+}
+
+// Watch subscribes to daemon events over the WebSocket endpoint.
+func (c *HTTPClient) Watch(ctx context.Context) (<-chan Event, error) {
+	wsURL := c.baseURL + "/api/v1/ws"
+	switch {
+	case strings.HasPrefix(wsURL, "https://"):
+		wsURL = "wss://" + strings.TrimPrefix(wsURL, "https://")
+	case strings.HasPrefix(wsURL, "http://"):
+		wsURL = "ws://" + strings.TrimPrefix(wsURL, "http://")
+	}
+
+	header := http.Header{}
+	if c.apiKey != "" {
+		header.Set("X-API-Key", c.apiKey)
+	}
+
+	conn, resp, err := websocket.DefaultDialer.DialContext(ctx, wsURL, header) //nolint:bodyclose // body closed below
+	if err != nil {
+		if resp != nil {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("failed to connect to %s (status %d): %w", wsURL, resp.StatusCode, err)
+		}
+		return nil, fmt.Errorf("failed to connect to %s: %w", wsURL, err)
+	}
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+
+	events := make(chan Event, 64)
+	done := make(chan struct{})
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.WriteControl(websocket.CloseMessage,
+				websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+				time.Now().Add(time.Second))
+			_ = conn.Close()
+		case <-done:
+		}
+	}()
+
+	go func() {
+		defer close(events)
+		defer close(done)
+		defer conn.Close()
+		for {
+			_, msg, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var e Event
+			if err := json.Unmarshal(msg, &e); err != nil {
+				c.logger.Warn("watch: skipping malformed event", "error", err)
+				continue
+			}
+			select {
+			case events <- e:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return events, nil
+}

--- a/pkg/client/watch_test.go
+++ b/pkg/client/watch_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -257,4 +258,146 @@ func TestHTTPClient_Watch(t *testing.T) {
 			t.Fatal("expected error")
 		}
 	})
+}
+
+// Every Watch goroutine must exit once its ctx is canceled or the peer
+// disconnects; the count must settle back to baseline afterwards.
+func TestWatch_NoGoroutineLeaks(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	baseline := runtime.NumGoroutine()
+
+	// Unix: cancel while streaming.
+	func() {
+		clientConn, serverConn := net.Pipe()
+		oldDial := dial
+		dial = pipeDialer(clientConn)
+		defer func() { dial = oldDial }()
+		go func() {
+			reader := bufio.NewReader(serverConn)
+			_, _ = reader.ReadBytes('\n')
+			ack, _ := json.Marshal(map[string]any{"status": "ok", "subscribed": true})
+			_, _ = serverConn.Write(append(ack, '\n'))
+			_, _ = reader.ReadBytes('\n') // block until closed
+		}()
+		ctx, cancel := context.WithCancel(context.Background())
+		ch, err := New(logger, "/tmp/fake.sock").Watch(ctx)
+		if err != nil {
+			t.Fatalf("Watch: %v", err)
+		}
+		cancel()
+		for range ch {
+		}
+		serverConn.Close()
+	}()
+
+	// Unix: server closes while streaming.
+	func() {
+		clientConn, serverConn := net.Pipe()
+		oldDial := dial
+		dial = pipeDialer(clientConn)
+		defer func() { dial = oldDial }()
+		go func() {
+			reader := bufio.NewReader(serverConn)
+			_, _ = reader.ReadBytes('\n')
+			ack, _ := json.Marshal(map[string]any{"status": "ok", "subscribed": true})
+			_, _ = serverConn.Write(append(ack, '\n'))
+			serverConn.Close()
+		}()
+		ch, err := New(logger, "/tmp/fake.sock").Watch(context.Background())
+		if err != nil {
+			t.Fatalf("Watch: %v", err)
+		}
+		for range ch {
+		}
+	}()
+
+	// Unix: handshake rejected.
+	func() {
+		clientConn, serverConn := net.Pipe()
+		oldDial := dial
+		dial = pipeDialer(clientConn)
+		defer func() { dial = oldDial }()
+		go func() {
+			reader := bufio.NewReader(serverConn)
+			_, _ = reader.ReadBytes('\n')
+			resp, _ := json.Marshal(map[string]any{"error": "nope"})
+			_, _ = serverConn.Write(append(resp, '\n'))
+		}()
+		if _, err := New(logger, "/tmp/fake.sock").Watch(context.Background()); err == nil {
+			t.Fatal("expected handshake error")
+		}
+		serverConn.Close()
+	}()
+
+	// Unix: cancel during handshake.
+	func() {
+		clientConn, serverConn := net.Pipe()
+		oldDial := dial
+		dial = pipeDialer(clientConn)
+		defer func() { dial = oldDial }()
+		go func() {
+			_, _ = bufio.NewReader(serverConn).ReadBytes('\n')
+		}()
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			cancel()
+		}()
+		if _, err := New(logger, "/tmp/fake.sock").Watch(ctx); err == nil {
+			t.Fatal("expected handshake error")
+		}
+		serverConn.Close()
+	}()
+
+	// WebSocket: cancel while streaming, then server close on a second watch.
+	// httptest stops tracking hijacked conns, so the server side must be
+	// closed explicitly rather than via CloseClientConnections.
+	func() {
+		upgrader := websocket.Upgrader{}
+		serverConns := make(chan *websocket.Conn, 2)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			conn, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+			serverConns <- conn
+			for {
+				if _, _, err := conn.ReadMessage(); err != nil {
+					return
+				}
+			}
+		}))
+		defer srv.Close()
+
+		c := NewHTTP(logger, srv.URL, "")
+		ctx, cancel := context.WithCancel(context.Background())
+		ch, err := c.Watch(ctx)
+		if err != nil {
+			t.Fatalf("Watch: %v", err)
+		}
+		<-serverConns
+		cancel()
+		for range ch {
+		}
+
+		ch2, err := c.Watch(context.Background())
+		if err != nil {
+			t.Fatalf("Watch: %v", err)
+		}
+		(<-serverConns).Close()
+		for range ch2 {
+		}
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= baseline {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	buf := make([]byte, 1<<16)
+	n := runtime.Stack(buf, true)
+	t.Fatalf("goroutines leaked: baseline %d, now %d\n%s", baseline, runtime.NumGoroutine(), buf[:n])
 }

--- a/pkg/client/watch_test.go
+++ b/pkg/client/watch_test.go
@@ -117,6 +117,36 @@ func TestClient_Watch(t *testing.T) {
 		}
 	})
 
+	t.Run("context cancel during handshake", func(t *testing.T) {
+		clientConn, serverConn := net.Pipe()
+		oldDial := dial
+		dial = pipeDialer(clientConn)
+		defer func() { dial = oldDial }()
+
+		go func() {
+			// Swallow the subscribe request, never send the ack.
+			_, _ = bufio.NewReader(serverConn).ReadBytes('\n')
+		}()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := New(logger, "/tmp/fake.sock").Watch(ctx)
+			errCh <- err
+		}()
+
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+		select {
+		case err := <-errCh:
+			if err == nil {
+				t.Fatal("expected handshake error")
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("Watch did not return promptly after cancel")
+		}
+	})
+
 	t.Run("server error response", func(t *testing.T) {
 		clientConn, serverConn := net.Pipe()
 		oldDial := dial

--- a/pkg/client/watch_test.go
+++ b/pkg/client/watch_test.go
@@ -1,0 +1,230 @@
+package client
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func pipeDialer(conn net.Conn) func(network, address string) (net.Conn, error) {
+	return func(network, address string) (net.Conn, error) {
+		return conn, nil
+	}
+}
+
+func writeEvent(t *testing.T, w interface{ Write([]byte) (int, error) }, eventType string) {
+	t.Helper()
+	e := Event{Type: eventType, Timestamp: time.Now(), Data: json.RawMessage(`{"id":"light-1"}`)}
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	if _, err := w.Write(append(data, '\n')); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+}
+
+func TestClient_Watch(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+
+	newWatchServer := func(t *testing.T, serverConn net.Conn) {
+		t.Helper()
+		go func() {
+			reader := bufio.NewReader(serverConn)
+			line, err := reader.ReadBytes('\n')
+			if err != nil {
+				return
+			}
+			var req map[string]string
+			if err := json.Unmarshal(line, &req); err != nil || req["action"] != "subscribe_events" {
+				serverConn.Close()
+				return
+			}
+			ack, _ := json.Marshal(map[string]any{"status": "ok", "subscribed": true})
+			_, _ = serverConn.Write(append(ack, '\n'))
+		}()
+	}
+
+	t.Run("receives events until server closes", func(t *testing.T) {
+		clientConn, serverConn := net.Pipe()
+		oldDial := dial
+		dial = pipeDialer(clientConn)
+		defer func() { dial = oldDial }()
+
+		newWatchServer(t, serverConn)
+
+		c := New(logger, "/tmp/fake.sock")
+		events, err := c.Watch(context.Background())
+		if err != nil {
+			t.Fatalf("Watch failed: %v", err)
+		}
+
+		writeEvent(t, serverConn, "light.state_changed")
+		writeEvent(t, serverConn, "group.updated")
+
+		e1 := <-events
+		if e1.Type != "light.state_changed" {
+			t.Fatalf("unexpected event type: %s", e1.Type)
+		}
+		e2 := <-events
+		if e2.Type != "group.updated" {
+			t.Fatalf("unexpected event type: %s", e2.Type)
+		}
+
+		serverConn.Close()
+		select {
+		case _, ok := <-events:
+			if ok {
+				t.Fatal("expected channel close after server disconnect")
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for channel close")
+		}
+	})
+
+	t.Run("context cancel closes channel", func(t *testing.T) {
+		clientConn, serverConn := net.Pipe()
+		oldDial := dial
+		dial = pipeDialer(clientConn)
+		defer func() { dial = oldDial }()
+
+		newWatchServer(t, serverConn)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		c := New(logger, "/tmp/fake.sock")
+		events, err := c.Watch(ctx)
+		if err != nil {
+			t.Fatalf("Watch failed: %v", err)
+		}
+
+		cancel()
+		select {
+		case _, ok := <-events:
+			if ok {
+				t.Fatal("expected channel close after cancel")
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for channel close")
+		}
+	})
+
+	t.Run("server error response", func(t *testing.T) {
+		clientConn, serverConn := net.Pipe()
+		oldDial := dial
+		dial = pipeDialer(clientConn)
+		defer func() { dial = oldDial }()
+
+		go func() {
+			reader := bufio.NewReader(serverConn)
+			_, _ = reader.ReadBytes('\n')
+			resp, _ := json.Marshal(map[string]any{"error": "not supported"})
+			_, _ = serverConn.Write(append(resp, '\n'))
+		}()
+
+		c := New(logger, "/tmp/fake.sock")
+		if _, err := c.Watch(context.Background()); err == nil || !strings.Contains(err.Error(), "not supported") {
+			t.Fatalf("expected server error, got: %v", err)
+		}
+	})
+
+	t.Run("malformed event is skipped", func(t *testing.T) {
+		clientConn, serverConn := net.Pipe()
+		oldDial := dial
+		dial = pipeDialer(clientConn)
+		defer func() { dial = oldDial }()
+
+		newWatchServer(t, serverConn)
+
+		c := New(logger, "/tmp/fake.sock")
+		events, err := c.Watch(context.Background())
+		if err != nil {
+			t.Fatalf("Watch failed: %v", err)
+		}
+
+		if _, err := serverConn.Write([]byte("{not json\n")); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		writeEvent(t, serverConn, "light.removed")
+
+		e := <-events
+		if e.Type != "light.removed" {
+			t.Fatalf("unexpected event type: %s", e.Type)
+		}
+		serverConn.Close()
+	})
+}
+
+func TestHTTPClient_Watch(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	upgrader := websocket.Upgrader{}
+
+	t.Run("receives events over websocket", func(t *testing.T) {
+		gotKey := make(chan string, 1)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotKey <- r.Header.Get("X-API-Key")
+			conn, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				return
+			}
+			defer conn.Close()
+			e := Event{Type: "light.discovered", Timestamp: time.Now(), Data: json.RawMessage(`{"id":"light-1"}`)}
+			data, _ := json.Marshal(e)
+			_ = conn.WriteMessage(websocket.TextMessage, data)
+			// Hold the connection open until the client disconnects.
+			for {
+				if _, _, err := conn.ReadMessage(); err != nil {
+					return
+				}
+			}
+		}))
+		defer srv.Close()
+
+		c := NewHTTP(logger, srv.URL, "secret")
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		events, err := c.Watch(ctx)
+		if err != nil {
+			t.Fatalf("Watch failed: %v", err)
+		}
+		if key := <-gotKey; key != "secret" {
+			t.Fatalf("expected API key header, got %q", key)
+		}
+
+		e := <-events
+		if e.Type != "light.discovered" {
+			t.Fatalf("unexpected event type: %s", e.Type)
+		}
+
+		cancel()
+		select {
+		case _, ok := <-events:
+			if ok {
+				t.Fatal("expected channel close after cancel")
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for channel close")
+		}
+	})
+
+	t.Run("dial failure", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+
+		c := NewHTTP(logger, srv.URL, "")
+		if _, err := c.Watch(context.Background()); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Implements the client half of #29. The daemon side (event bus, socket `subscribe_events`, WebSocket `/api/v1/ws`) already shipped in 14ade72 with no consumers — this adds the consumer API.

- New optional `Watcher` interface in `pkg/client`, implemented by both transports:
  - Unix socket: `subscribe_events` handshake, then NDJSON event stream
  - HTTP: WebSocket at `/api/v1/ws` with `X-API-Key` auth
- `ClientInterface` is unchanged, so existing mocks keep working
- Channel closes on ctx cancellation or connection drop; callers re-subscribe (reconnect/backoff intentionally left to the caller)
- Leak-hardened: shared `streamEvents` pump, ctx-cancellable handshake, WS read deadline refreshed by server pings so half-open peers fail fast
- Goroutine-leak test covering cancel / server-close / handshake-failure on both transports (50 clean iterations under `-race`)
- End-to-end test wiring `client.Watch` to the real daemon socket handler; also verified live against a running keylightd 0.1.6 with real Elgato hardware
- Bumps vite 8.0.16 → 8.1.3 in the tray frontend lockfile

Tray consumption of `Watch` is follow-up work.

Closes #29