### PR TITLE
feat(tray): drive UI refresh from daemon events instead of polling

### DIFF
--- a/contrib/keylightd-tray/app.go
+++ b/contrib/keylightd-tray/app.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -33,6 +34,9 @@ type App struct {
 	customCSSPath string
 	cssWatcher    *fsnotify.Watcher
 	watchedDirs   map[string]bool
+	watchMu       sync.Mutex
+	watchCancel   context.CancelFunc
+	watchAlive    bool
 }
 
 // SetTrayManager sets the tray manager reference
@@ -142,8 +146,75 @@ func (a *App) startup(ctx context.Context) {
 	// Create client
 	a.client = client.New(a.logger, socket)
 
+	a.startWatch(ctx)
+
 	// Start watching custom.css for changes
 	go a.watchCustomCSS()
+}
+
+// startWatch (re)starts the event subscription for the current client.
+func (a *App) startWatch(ctx context.Context) {
+	a.watchMu.Lock()
+	if a.watchCancel != nil {
+		a.watchCancel()
+	}
+	w, ok := a.client.(client.Watcher)
+	if !ok {
+		a.watchCancel = nil
+		a.watchMu.Unlock()
+		return
+	}
+	wctx, cancel := context.WithCancel(ctx)
+	a.watchCancel = cancel
+	a.watchMu.Unlock()
+
+	go a.runWatch(wctx, w)
+}
+
+// runWatch consumes daemon events and forwards them to the frontend,
+// resubscribing with backoff whenever the stream drops.
+func (a *App) runWatch(ctx context.Context, w client.Watcher) {
+	backoff := time.Second
+	for {
+		ch, err := w.Watch(ctx)
+		if err == nil {
+			backoff = time.Second
+			a.setWatchAlive(true)
+			for e := range ch {
+				runtime.EventsEmit(ctx, "state:changed", e.Type)
+			}
+			if ctx.Err() != nil {
+				return // canceled: replacement watch owns the status now
+			}
+			a.setWatchAlive(false)
+			a.logger.Info("watch: stream closed, resubscribing")
+		} else if ctx.Err() == nil {
+			a.logger.Warn("watch: subscribe failed, falling back to polling", "error", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < 30*time.Second {
+			backoff *= 2
+		}
+	}
+}
+
+func (a *App) setWatchAlive(alive bool) {
+	a.watchMu.Lock()
+	a.watchAlive = alive
+	a.watchMu.Unlock()
+	runtime.EventsEmit(a.ctx, "watch:status", alive)
+}
+
+// WatchAlive reports whether the event subscription is currently active.
+func (a *App) WatchAlive() bool {
+	a.watchMu.Lock()
+	defer a.watchMu.Unlock()
+	return a.watchAlive
 }
 
 // SaveSettings saves the connection settings and reconnects the client
@@ -170,6 +241,7 @@ func (a *App) SaveSettings(settings Settings) error {
 		a.client = client.New(a.logger, socketPath)
 	}
 
+	a.startWatch(a.ctx) //nolint:contextcheck // Wails binding has no ctx param
 	return nil
 }
 

--- a/contrib/keylightd-tray/frontend/src/lib/wailsjs/go/main/App.d.ts
+++ b/contrib/keylightd-tray/frontend/src/lib/wailsjs/go/main/App.d.ts
@@ -45,3 +45,5 @@ export function SetLightState(arg1:string,arg2:string,arg3:any):Promise<void>;
 export function SetTrayManager(arg1:main.TrayManager):Promise<void>;
 
 export function ShowWindow():Promise<void>;
+
+export function WatchAlive():Promise<boolean>;

--- a/contrib/keylightd-tray/frontend/src/lib/wailsjs/go/main/App.js
+++ b/contrib/keylightd-tray/frontend/src/lib/wailsjs/go/main/App.js
@@ -89,3 +89,7 @@ export function SetTrayManager(arg1) {
 export function ShowWindow() {
   return window['go']['main']['App']['ShowWindow']();
 }
+
+export function WatchAlive() {
+  return window['go']['main']['App']['WatchAlive']();
+}

--- a/contrib/keylightd-tray/frontend/src/main.js
+++ b/contrib/keylightd-tray/frontend/src/main.js
@@ -1,5 +1,6 @@
 // Wails runtime bindings
 let GetStatus, GetVersion, GetDaemonVersion, SetLightState, SetGroupState;
+let WatchAlive;
 
 // Check if running in Wails or browser
 if (window.go && window.go.main && window.go.main.App) {
@@ -8,6 +9,7 @@ if (window.go && window.go.main && window.go.main.App) {
   GetDaemonVersion = window.go.main.App.GetDaemonVersion;
   SetLightState = window.go.main.App.SetLightState;
   SetGroupState = window.go.main.App.SetGroupState;
+  WatchAlive = window.go.main.App.WatchAlive;
 } else {
   // Mock functions for browser testing
   console.warn("Wails runtime not available - using mock data");
@@ -56,6 +58,8 @@ if (window.go && window.go.main && window.go.main.App) {
   SetGroupState = async (id, prop, value) => {
     console.log(`SetGroupState: ${id} ${prop} = ${value}`);
   };
+
+  WatchAlive = async () => false;
 }
 
 // Additional Wails bindings for group management
@@ -138,6 +142,13 @@ let pauseReasons = new Set();
 let currentIntervalMs = 2500;
 let lastStatusHash = null;
 
+// When the daemon event stream is up, polling drops to a slow safety net
+// and refreshes are driven by pushed events instead.
+let userIntervalMs = 2500;
+let watchAlive = false;
+let watchRefreshTimer = null;
+const WATCH_SAFETY_NET_MS = 90000;
+
 // Tracks the *shape* of what's currently rendered (the sorted list of card
 // IDs). When a refresh comes in with the same shape, we update card values
 // in place via updateSliderValues — no innerHTML replacement, so we don't
@@ -172,11 +183,34 @@ function applyPauseState() {
 }
 
 function changePollingInterval(intervalMs) {
-  currentIntervalMs = intervalMs;
+  userIntervalMs = intervalMs;
+  applyEffectiveInterval();
+}
+
+function applyEffectiveInterval() {
+  currentIntervalMs = watchAlive
+    ? Math.max(WATCH_SAFETY_NET_MS, userIntervalMs)
+    : userIntervalMs;
   if (refreshInterval) {
     clearInterval(refreshInterval);
     refreshInterval = setInterval(refresh, currentIntervalMs);
   }
+}
+
+function setupWatchEvents() {
+  if (!window.runtime || !window.runtime.EventsOn) return;
+  window.runtime.EventsOn("watch:status", (alive) => {
+    watchAlive = !!alive;
+    applyEffectiveInterval();
+  });
+  window.runtime.EventsOn("state:changed", () => {
+    if (pauseReasons.size > 0) return; // hidden/dragging: refresh happens on resume
+    if (watchRefreshTimer) clearTimeout(watchRefreshTimer);
+    watchRefreshTimer = setTimeout(() => {
+      watchRefreshTimer = null;
+      refresh();
+    }, 250);
+  });
 }
 
 function setupVisibilityPause() {
@@ -238,6 +272,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   // Hook window-visibility events from Go before first refresh so a
   // window that opens already-visible doesn't miss the initial event.
   setupVisibilityPause();
+  setupWatchEvents();
 
   // Initial load
   await refresh();
@@ -255,10 +290,15 @@ document.addEventListener("DOMContentLoaded", async () => {
   // Start the polling loop at the user's configured rate. Replaces the
   // old hardcoded 1000ms initial poll — never poll faster than the user
   // explicitly chose.
-  currentIntervalMs = parseInt(
-    localStorage.getItem("refreshInterval") || "2500",
-  );
-  if (currentIntervalMs < 1000) currentIntervalMs = 1000;
+  userIntervalMs = parseInt(localStorage.getItem("refreshInterval") || "2500");
+  if (userIntervalMs < 1000) userIntervalMs = 1000;
+  // The watch may have connected before this listener registered.
+  try {
+    watchAlive = !!(await WatchAlive());
+  } catch (e) {
+    watchAlive = false;
+  }
+  applyEffectiveInterval();
   applyPauseState();
 });
 


### PR DESCRIPTION
## Summary

Completes #29: the tray now consumes the `Watch` API shipped in v0.1.7.

- Tray subscribes via `client.Watch` on startup and after settings changes
- Daemon events trigger a debounced (250ms) UI refresh
- While the event stream is healthy, polling stretches to a 90s safety net
- On stream failure or an older daemon, falls back to the configured poll interval with 1s→30s backoff resubscribe
- Hidden-window pause and diff-render behavior unchanged

Tested live against a running daemon: subscription confirmed in daemon logs, state changes pushed via keylightctl reflected in the UI, no polling churn while idle.