### PR TITLE
fix(tray): keep tray state in sync while the window is hidden

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: stable
           cache: true
@@ -130,7 +130,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: stable
           cache: true
@@ -205,7 +205,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: stable
           cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: stable
           cache: true

--- a/contrib/keylightd-tray/app.go
+++ b/contrib/keylightd-tray/app.go
@@ -37,7 +37,20 @@ type App struct {
 	watchMu       sync.Mutex
 	watchCancel   context.CancelFunc
 	watchAlive    bool
+	trayRefresh   chan struct{}
 }
+
+// Tray refresh cadence. The tray must stay correct while the window is
+// hidden, when the frontend deliberately stops refreshing — so the Go side
+// owns tray state rather than piggy-backing on frontend GetStatus calls.
+const (
+	// trayRefreshDebounce coalesces bursts of daemon events (a group toggle
+	// emits one event per light) into a single status fetch.
+	trayRefreshDebounce = 200 * time.Millisecond
+	// traySafetyNetInterval bounds tray staleness when the event stream is
+	// down and no explicit refresh is requested.
+	traySafetyNetInterval = 30 * time.Second
+)
 
 // SetTrayManager sets the tray manager reference
 func (a *App) SetTrayManager(tray *TrayManager) {
@@ -127,9 +140,10 @@ type Status struct {
 // NewApp creates a new App application struct
 func NewApp(version, commit, buildDate string) *App {
 	return &App{
-		version:   version,
-		commit:    commit,
-		buildDate: buildDate,
+		version:     version,
+		commit:      commit,
+		buildDate:   buildDate,
+		trayRefresh: make(chan struct{}, 1),
 	}
 }
 
@@ -148,8 +162,60 @@ func (a *App) startup(ctx context.Context) {
 
 	a.startWatch(ctx)
 
+	go a.runTrayRefresh(ctx)
+
 	// Start watching custom.css for changes
 	go a.watchCustomCSS()
+}
+
+// SignalTrayRefresh requests a tray icon/menu refresh. It never blocks: a
+// refresh is already pending when the buffer is full, and that pending
+// refresh will observe the same state this call would have.
+func (a *App) SignalTrayRefresh() {
+	if a.trayRefresh == nil {
+		return
+	}
+	select {
+	case a.trayRefresh <- struct{}{}:
+	default:
+	}
+}
+
+// runTrayRefresh keeps the tray icon, tooltip and menu in sync with the
+// daemon independently of the frontend.
+//
+// The window is hidden most of the time, and while hidden the frontend stops
+// calling GetStatus (see setPollingPaused in main.js). Without this loop the
+// tray would keep displaying whatever state was current when the window was
+// last visible — so toggling a light from the tray menu left the icon showing
+// the pre-toggle state until the window was reopened.
+func (a *App) runTrayRefresh(ctx context.Context) {
+	ticker := time.NewTicker(traySafetyNetInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-a.trayRefresh:
+			// Let a burst of related events settle, then collapse them
+			// into the single fetch below.
+			select {
+			case <-time.After(trayRefreshDebounce):
+			case <-ctx.Done():
+				return
+			}
+			select {
+			case <-a.trayRefresh:
+			default:
+			}
+		case <-ticker.C:
+		}
+
+		if _, err := a.GetStatus(); err != nil {
+			a.logger.Debug("tray refresh: status unavailable", "error", err)
+		}
+	}
 }
 
 // startWatch (re)starts the event subscription for the current client.
@@ -182,6 +248,9 @@ func (a *App) runWatch(ctx context.Context, w client.Watcher) {
 			a.setWatchAlive(true)
 			for e := range ch {
 				runtime.EventsEmit(ctx, "state:changed", e.Type)
+				// The frontend ignores this event while hidden, so the
+				// tray refreshes off the same stream directly.
+				a.SignalTrayRefresh()
 			}
 			if ctx.Err() != nil {
 				return // canceled: replacement watch owns the status now

--- a/contrib/keylightd-tray/tray.go
+++ b/contrib/keylightd-tray/tray.go
@@ -249,7 +249,11 @@ func (t *TrayManager) toggleGroup(groupID string) {
 
 	for _, group := range status.Groups {
 		if group.ID == groupID {
-			_ = t.app.SetGroupState(groupID, "on", !group.On)
+			if err := t.app.SetGroupState(groupID, "on", !group.On); err == nil {
+				// GetStatus above painted the pre-toggle state; repaint
+				// rather than wait for the window to be reopened.
+				t.app.SignalTrayRefresh()
+			}
 			return
 		}
 	}
@@ -264,7 +268,11 @@ func (t *TrayManager) toggleLight(lightID string) {
 
 	for _, light := range status.Lights {
 		if light.ID == lightID {
-			_ = t.app.SetLightState(lightID, "on", !light.On)
+			if err := t.app.SetLightState(lightID, "on", !light.On); err == nil {
+				// GetStatus above painted the pre-toggle state; repaint
+				// rather than wait for the window to be reopened.
+				t.app.SignalTrayRefresh()
+			}
 			return
 		}
 	}

--- a/contrib/keylightd-tray/tray_refresh_test.go
+++ b/contrib/keylightd-tray/tray_refresh_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeClient records how often the tray refresh loop fetched status.
+type fakeClient struct {
+	mu     sync.Mutex
+	lights map[string]any
+	calls  atomic.Int64
+}
+
+func newFakeClient() *fakeClient {
+	return &fakeClient{
+		lights: map[string]any{
+			"light-1": map[string]any{"name": "Key Light", "on": true},
+		},
+	}
+}
+
+func (f *fakeClient) setOn(on bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.lights["light-1"] = map[string]any{"name": "Key Light", "on": on}
+}
+
+func (f *fakeClient) GetLights() (map[string]any, error) {
+	f.calls.Add(1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make(map[string]any, len(f.lights))
+	for k, v := range f.lights {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func (f *fakeClient) GetGroups() ([]map[string]any, error) { return nil, nil }
+
+func (f *fakeClient) GetVersion() (map[string]any, error)     { return nil, nil }
+func (f *fakeClient) GetLight(string) (map[string]any, error) { return nil, nil }
+func (f *fakeClient) SetLightState(string, string, any) error { return nil }
+func (f *fakeClient) CreateGroup(string) error                { return nil }
+func (f *fakeClient) GetGroup(string) (map[string]any, error) { return nil, nil }
+func (f *fakeClient) SetGroupState(string, string, any) error { return nil }
+func (f *fakeClient) DeleteGroup(string) error                { return nil }
+func (f *fakeClient) SetGroupLights(string, []string) error   { return nil }
+func (f *fakeClient) ListAPIKeys() ([]map[string]any, error)  { return nil, nil }
+func (f *fakeClient) DeleteAPIKey(string) error               { return nil }
+func (f *fakeClient) AddAPIKey(string, float64) (map[string]any, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeClient) SetAPIKeyDisabledStatus(string, bool) (map[string]any, error) {
+	return nil, errors.New("not implemented")
+}
+
+func newTestApp(c *fakeClient) *App {
+	app := NewApp("test", "test", "test")
+	app.client = c
+	app.logger = slog.New(slog.DiscardHandler)
+	return app
+}
+
+func waitForCalls(t *testing.T, c *fakeClient, want int64, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if c.calls.Load() >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("expected at least %d status fetches, got %d", want, c.calls.Load())
+}
+
+// The tray must refresh from Go, not from the frontend: the window is hidden
+// most of the time and the frontend stops polling while hidden.
+func TestRunTrayRefreshOnSignal(t *testing.T) {
+	c := newFakeClient()
+	app := newTestApp(c)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go app.runTrayRefresh(ctx)
+
+	app.SignalTrayRefresh()
+	waitForCalls(t, c, 1, 2*time.Second)
+}
+
+// A group toggle emits one daemon event per light; those must collapse into
+// a single status fetch rather than one fetch each.
+func TestRunTrayRefreshCoalescesBurst(t *testing.T) {
+	c := newFakeClient()
+	app := newTestApp(c)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go app.runTrayRefresh(ctx)
+
+	for range 20 {
+		app.SignalTrayRefresh()
+	}
+	waitForCalls(t, c, 1, 2*time.Second)
+
+	time.Sleep(2 * trayRefreshDebounce)
+	if got := c.calls.Load(); got > 2 {
+		t.Errorf("burst of 20 signals produced %d status fetches, want <= 2", got)
+	}
+}
+
+func TestSignalTrayRefreshNeverBlocks(t *testing.T) {
+	app := NewApp("test", "test", "test") // no refresh loop draining the channel
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 100 {
+			app.SignalTrayRefresh()
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SignalTrayRefresh blocked when a refresh was already pending")
+	}
+}
+
+func TestRunTrayRefreshStopsOnContextCancel(t *testing.T) {
+	c := newFakeClient()
+	app := newTestApp(c)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan struct{})
+	go func() {
+		app.runTrayRefresh(ctx)
+		close(stopped)
+	}()
+
+	app.SignalTrayRefresh()
+	waitForCalls(t, c, 1, 2*time.Second)
+	cancel()
+
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runTrayRefresh did not exit after context cancellation")
+	}
+}
+
+// The status the tray renders must be the post-toggle state, not the state
+// read before the set call.
+func TestGetStatusReflectsLatestState(t *testing.T) {
+	c := newFakeClient()
+	app := newTestApp(c)
+
+	status, err := app.GetStatus()
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if status.OnCount != 1 {
+		t.Fatalf("OnCount = %d, want 1", status.OnCount)
+	}
+
+	c.setOn(false)
+
+	status, err = app.GetStatus()
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if status.OnCount != 0 || status.OffCount != 1 {
+		t.Errorf("after toggle: OnCount = %d, OffCount = %d, want 0 and 1", status.OnCount, status.OffCount)
+	}
+}


### PR DESCRIPTION
## Problem

The tray icon can display the opposite of the real light state after toggling from the dropdown menu. Opening the main window instantly corrects it.

The tray had no state of its own: the icon, tooltip and menu checkmarks were only ever updated as a side effect of `App.GetStatus()`, and `GetStatus()` is only called by the frontend. But the frontend stops refreshing while the window is hidden (`setPollingPaused("hidden", …)`, `main.js:222`) and the `state:changed` handler bails out for the same reason (`main.js:207`) — so nothing repaints the tray in the state it spends most of its time in.

The reported symptom follows directly:

1. Click a light in the tray menu → `toggleLight` calls `GetStatus()` to read the current value, **which repaints the tray with the pre-toggle state**.
2. `SetLightState` flips the light.
3. Window hidden → frontend ignores the resulting daemon event → nothing calls `GetStatus()` again.
4. Tray shows the inverse until the window is reopened, which unpauses polling and corrects it.

This predates the event-driven refresh work — 500a495 introduced pause-when-hidden, and #41 removed the polling that had been papering over it.

## Fix

Ownership of tray state moves to the Go side, independent of window visibility:

- `App.runTrayRefresh` — goroutine started at startup, refreshing on demand with a 200ms debounce (a group toggle emits one daemon event per light) plus a 30s safety net for when the event stream is down.
- `App.SignalTrayRefresh()` — non-blocking; a full buffer means a refresh is already pending and will observe the same state.
- `runWatch` signals per daemon event, so changes made from anywhere (CLI, another client) track while hidden.
- `toggleLight` / `toggleGroup` signal after a successful set rather than waiting on the event round-trip.

## Also here

`actions/setup-go` bumped to v7 in all five places. `test.yml` and `docs.yml` were on v5 while `build-release.yml` was on v6; dependabot's github-actions PR limit of 3 had the bump queued behind #38/#39/#42. v6.0.0's breaking changes (node24 runtime, toolchain selection) don't apply — every job uses `go-version: stable` or `go-version-file`, and go.mod has no `toolchain` directive.

## Testing

New `tray_refresh_test.go`: signal triggers a refresh, bursts coalesce, `SignalTrayRefresh` never blocks, the loop exits on context cancellation, and status reflects post-toggle state.

`go build ./...`, the full test suite (including `./contrib/...`), and `golangci-lint run ./...` all pass against the newly merged dependency set (huma 2.39.0, wails 2.13.0).

Not verified: the tray binary running end to end. Worth a manual check that toggling from the menu flips the icon within ~200ms with the window closed.